### PR TITLE
Add max-age=0 to cache-control header.

### DIFF
--- a/web/pages/api/markdown_image/[githubUsername].ts
+++ b/web/pages/api/markdown_image/[githubUsername].ts
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
     })
 
     res.setHeader('Content-Type', 'image/svg+xml')
-    res.setHeader('cache-control', 'no-cache, no-store, must-revalidate')
+    res.setHeader('Cache-Control', 'max-age=0, no-cache, no-store, must-revalidate')
     res.end(svgData)
 }
 


### PR DESCRIPTION
This attempt was successful.

GitHub no longer caches the image, and rather just proxies requests through their camo server.
No problem! Now we can count views.