### PR TITLE
Add max-age=0 to cache-control header.

### DIFF
--- a/web/pages/api/markdown_image/[githubUsername].ts
+++ b/web/pages/api/markdown_image/[githubUsername].ts
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
     })
 
     res.setHeader('Content-Type', 'image/svg+xml')
-    res.setHeader('cache-control', 'no-cache, no-store, must-revalidate')
+    res.setHeader('Cache-Control', 'max-age=0, no-cache, no-store, must-revalidate')
     res.end(svgData)
 }
 


### PR DESCRIPTION
This forces GitHub to make requests to our server through their camo proxy every time rather than caching our markdown images in their CDN.