### PR TITLE
polish settings page functionality

### DIFF
--- a/Git Streak Tracker Widget/Git_Streak_Tracker_Widget.swift
+++ b/Git Streak Tracker Widget/Git_Streak_Tracker_Widget.swift
@@ -236,10 +236,10 @@ struct Git_Streak_Tracker_WidgetEntryView : View {
         switch family {
         case .systemSmall:
             Git_Streak_Tracker_Small_Widget_View(entry: entry)
-                .environmentObject(UserStore(username: "", contributionData: ContributionData())) // I do this to make sure it updates with the app's state
+                .environmentObject(UserStore(contributionData: ContributionData())) // I do this to make sure it updates with the app's state
         default:
             Git_Streak_Tracker_Medium_Widget_View(entry: entry)
-                .environmentObject(UserStore(username: "", contributionData: ContributionData())) // I do this to make sure it updates with the app's state
+                .environmentObject(UserStore(contributionData: ContributionData())) // I do this to make sure it updates with the app's state
         }
 
     }

--- a/Git Streak Tracker/ContentView.swift
+++ b/Git Streak Tracker/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
     
     func onAppear(){
         if !userStore.username.isEmpty {
-            userStore.setUsername(username: userStore.username) // triggers an update
+            userStore.reloadContributionData()
         } else {
             viewStore.switchTab(tab: 1) // if no username exists in storage, send them to settings page
         }
@@ -87,7 +87,7 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .environmentObject(UserStore(username: "", contributionData: ContributionData()))
+            .environmentObject(UserStore(contributionData: ContributionData()))
             .environmentObject(ViewStore())
     }
 }

--- a/Git Streak Tracker/Git_Streak_TrackerApp.swift
+++ b/Git Streak Tracker/Git_Streak_TrackerApp.swift
@@ -12,7 +12,7 @@ struct Git_Streak_TrackerApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(UserStore(username: "", contributionData: ContributionData()))
+                .environmentObject(UserStore(contributionData: ContributionData()))
                 .environmentObject(ViewStore())
         }
     }

--- a/Git Streak Tracker/ProfileOverviewView.swift
+++ b/Git Streak Tracker/ProfileOverviewView.swift
@@ -142,7 +142,7 @@ struct ProfileOverviewView: View {
 
                     Group {
                         Text(userStore.contributionData.name)
-                            .font(.system(size: 40))
+                            .font(.system(size: 35))
                             .fontWeight(.bold)
                             .foregroundColor(.white)
                             .padding(.bottom, -8)
@@ -197,7 +197,7 @@ struct ProfileOverviewView: View {
 struct ProfileOverviewView_Previews: PreviewProvider {
     static var previews: some View {
         return ProfileOverviewView()
-            .environmentObject(UserStore(username: "", contributionData: ContributionData(
+            .environmentObject(UserStore(contributionData: ContributionData(
                 streakLength: 10,
                 todayComplete: false,
                 allContributions: generateContributionDays(),

--- a/Git Streak Tracker/SettingsView.swift
+++ b/Git Streak Tracker/SettingsView.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import SwiftUI
-import WidgetKit
+
 import SwiftUIFontIcon
 
 let debouncer = Debouncer(delay: 0.5)
@@ -20,10 +20,11 @@ struct SettingsView: View {
     
     // Actions
     func loadInputField() {
-        inputValue = userStore.username
+        inputValue = userStore.stagedUsername
     }
     
     func handleInputChanged() {
+        userStore.stagedUsername = ""
         inputValue = inputValue.trimmingCharacters(in: .whitespacesAndNewlines)
         userStore.error = !isValidGHUsername(uname: inputValue) && inputValue != ""
         debouncer.renewInterval {
@@ -36,8 +37,7 @@ struct SettingsView: View {
             return
         }
                 
-        userStore.setUsername(username: inputValue)
-        WidgetCenter.shared.reloadAllTimelines()
+        userStore.stageUsername(username: inputValue)
     }
     
     func handleSaveUsernamePress() {
@@ -63,7 +63,7 @@ struct SettingsView: View {
             return false
         }
         
-        return userStore.error || userStore.fetching || inputValue != userStore.username || inputValue == ""
+        return userStore.error || userStore.fetching || inputValue != userStore.stagedUsername || inputValue == ""
     }
     
     func getSaveUsernameBg() -> LinearGradient {
@@ -91,7 +91,7 @@ struct SettingsView: View {
             return ColorPallete.midRed
         }
         
-        if userStore.username.isEmpty || inputValue.isEmpty || userStore.username != inputValue {
+        if userStore.stagedUsername.isEmpty || inputValue.isEmpty || userStore.stagedUsername != inputValue {
             return .clear
         }
         
@@ -142,8 +142,6 @@ struct SettingsView: View {
                             loadInputField()
                         }
                  
-                            
-                            
                         HStack {
                             Text("GitHub Username")
                                 .foregroundColor(ColorPallete.lightestGreen)
@@ -162,7 +160,6 @@ struct SettingsView: View {
                                 )
                                 .offset(x: -4, y: 1)
                             }
-
                         }.offset(x: -60, y: -16)
 
                     }
@@ -195,7 +192,7 @@ struct SettingsView: View {
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView()
-            .environmentObject(UserStore(username: "", contributionData: ContributionData()))
+            .environmentObject(UserStore(contributionData: ContributionData()))
             .environmentObject(ViewStore())
     }
 }


### PR DESCRIPTION
* Remove unnecessary username argument from UserStore. 
* Utilize a buffer to store the username and contribution data that are managed by the SettingsView, so it's 
separated from the home view. Now, interactions with the settings page don't affect the home page until the user has pressed the save button.
* Call reloadAllTimelines in the UserStore where it belongs.
